### PR TITLE
Update service reference details in 02-comunicar-burocracia-cero.md

### DIFF
--- a/02-comunicar-burocracia-cero.md
+++ b/02-comunicar-burocracia-cero.md
@@ -29,8 +29,10 @@ Para consumir el servicio de integración desde X-ROAD, sigue estos pasos dentro
 
 > **Consulta la guía oficial para consumir servicios en X-ROAD:** [08_consumir_servicio.md](https://github.com/ogticrd/xroad-members/blob/master/08_consumir_servicio.md)
 > 
-> **Referencia del servicio:**  
-> `CNC:MONITOREO:INTEGRACION-DEV`
+> **Referencia del servicio:**
+>
+> - **Desarrollo:** `CNC:MONITOREO:INTEGRACION:DEV`
+> - **Producción:** `CNC:MONITOREO:INTEGRACION`
 
 ---
 


### PR DESCRIPTION
This pull request updates the reference information for consuming the integration service via X-ROAD in the `02-comunicar-burocracia-cero.md` file. The most important change is the addition of separate references for development and production environments.

### Updates to service references:

* Added distinct references for the development (`CNC:MONITOREO:INTEGRACION:DEV`) and production (`CNC:MONITOREO:INTEGRACION`) environments to clarify usage.